### PR TITLE
使用单独的方法实现中文着重号

### DIFF
--- a/ezexam.typ
+++ b/ezexam.typ
@@ -1,7 +1,7 @@
 #import "lib/const.typ": CIRCLE, EVERY_PAGE, EXAM, FIRST_PAGE, HANDOUTS, ODD_PAGE, TEXT
 #import "lib/counter.typ": counter-chapter, counter-question, counter-title
 #import "lib/config.typ": a3, a4, heiti, kaiti, roman
-#import "lib/tools.typ": page-restart, tag, text-figure, zh-arabic
+#import "lib/tools.typ": emph-dot, page-restart, tag, text-figure, zh-arabic
 #import "lib/choice.typ": choices
 #import "lib/question.typ": per-pts, question, sec-pts, sec-q-cnt, set-per-pts, tot-pts, tot-q-cnt
 #import "lib/paren-fillin.typ": fillin, fillinn, paren, parenn
@@ -39,7 +39,6 @@
   list-spacing: auto,
   list-indent: 0pt,
   ref-color: rgb("#0a6e96"),
-  strong-han-dot: false,
   resume: true,
   watermark: none,
   watermark-color: rgb("#f666"),
@@ -303,20 +302,6 @@
   let space = h(.25em, weak: true)
   show math.equation.where(block: false): it => space + math.display(it) + space
   show "∥": [#space\//#space]
-
-  // 中文着重号
-  let han-zi = regex("\p{Han}")
-  show strong: content => {
-    set text(weight: 700)
-    show han-zi: it => {
-      if strong-han-dot {
-        box(place(text("·", .8em), dx: .45em, dy: .75em) + text(weight: 400, it))
-      } else {
-        it
-      }
-    }
-    content.body
-  }
 
   if show-answer {
     answer-state.update(true)

--- a/ezexam.typ
+++ b/ezexam.typ
@@ -39,6 +39,7 @@
   list-spacing: auto,
   list-indent: 0pt,
   ref-color: rgb("#0a6e96"),
+  strong-han-dot: false,
   resume: true,
   watermark: none,
   watermark-color: rgb("#f666"),
@@ -306,7 +307,14 @@
   // 中文着重号
   let han-zi = regex("\p{Han}")
   show strong: content => {
-    show han-zi: it => box(place(text("·", .8em), dx: .45em, dy: .75em) + it)
+    set text(weight: 700)
+    show han-zi: it => {
+      if strong-han-dot {
+        box(place(text("·", .8em), dx: .45em, dy: .75em) + text(weight: 400, it))
+      } else {
+        it
+      }
+    }
     content.body
   }
 
@@ -317,4 +325,3 @@
 
   doc
 }
-

--- a/lib/tools.typ
+++ b/lib/tools.typ
@@ -106,6 +106,14 @@
     )#h(.5em, weak: true)]
 }
 
+#let _HAN-ZI = regex("\p{Han}")
+#let emph-dot(body) = {
+  show _HAN-ZI: it => box(
+    place(text("·", .8em), dx: .39em, dy: .75em) + it,
+  )
+  body
+}
+
 // 图文混排
 #let text-figure(
   figure: none,


### PR DESCRIPTION
## 问题

当前默认对中文使用着重号且英文加粗样式丢失。显然并不是所有情况下这种行为都是合理的。

## 解决方案

引入了新的参数 `strong-han-dot`（默认值 `false` ）控制中文是否使用着重号。

## 示例

```typ
#let test = [*abcd测试*]
#show: setup.with(paper: (height: auto, width: auto), page-numbering: none)
#test
#show: setup.with(paper: (height: auto, width: auto), page-numbering: none, strong-han-dot: true)
#test
```
<img width="383" height="304" alt="p1" src="https://github.com/user-attachments/assets/997af63b-d418-4985-ba5e-3ecfba4f804f" />  <img width="377" height="304" alt="p2" src="https://github.com/user-attachments/assets/45bac014-0cb3-4deb-9784-8c42aa6d93de" />

## 可能的问题

1.  `weight` 数值的更改，这可以通过再增加一个参数实现。不过我认为这个需求不大可以不考虑。